### PR TITLE
Prevent depot disable when loaded modules (closes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+
+#Gridware
+
+This is the repository for the Alces Gridware tool for installing and managing
+HPC software. Alces Gridware is intended to be used in an [Alces
+Clusterware](https://github.com/alces-software/clusterware) environment, such
+as [Alces Flight Compute](http://alces-flight.com/).
+
+##Development
+
+Gridware can be developed within an existing Clusterware environment. For
+example, to use a local version of the Gridware source inside an Alces
+Clusterware development Vagrant VM you can do the following:
+
+1. Mount the Gridware source to the appropriate location within the VM by
+   adding something like the following to the Vagrantfile, then running
+   `vagrant up`:
+
+   ```ruby
+  config.vm.synced_folder "path/to/gridware", "/opt/clusterware/opt/gridware"
+   ```
+
+2. Install the mounted version of Gridware within the VM by running
+   `bin/setup`.
+
+Gridware also has some tests; these can be run using `bin/rake test`.

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,8 @@
 require 'rake/testtask'
 
 Rake::TestTask.new do |t|
-  # Set up ruby environment - duplicated from libexec/actions/gridware
+  # Set up ruby environment - duplicated/adapted from
+  # $clusterware-services/gridware/libexec/actions/gridware
   ####
   ENV['cw_ROOT'] = '/opt/clusterware'
 
@@ -10,8 +11,8 @@ Rake::TestTask.new do |t|
   ENV['cw_GRIDWARE_root'] = v unless v.empty?
 
   ENV['ALCES_CONFIG_PATH'] ||= "#{ENV['cw_GRIDWARE_root']}/etc:#{ENV['cw_ROOT']}/etc"
-  ENV['BUNDLE_GEMFILE'] ||= "#{ENV['cw_ROOT']}/lib/ruby/Gemfile"
-  $: << "#{ENV['cw_ROOT']}/lib/ruby/lib"
+  ENV['BUNDLE_GEMFILE'] ||= "#{ENV['cw_ROOT']}/opt/gridware/Gemfile"
+  $: << "#{ENV['cw_ROOT']}/opt/gridware/lib"
 
   require 'rubygems'
   require 'bundler'

--- a/bin/rake
+++ b/bin/rake
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+setup() {
+    local a xdg_config
+    IFS=: read -a xdg_config <<< "${XDG_CONFIG_HOME:-$HOME/.config}:${XDG_CONFIG_DIRS:-/etc/xdg}"
+    for a in "${xdg_config[@]}"; do
+        if [ -e "${a}"/clusterware/config.rc ]; then
+            source "${a}"/clusterware/config.rc
+            break
+        fi
+    done
+    if [ -z "${cw_ROOT}" ]; then
+        echo "$0: unable to locate clusterware configuration"
+        exit 1
+    fi
+    kernel_load
+}
+
+main() {
+    # Run Clusterware's Rake.
+    "${cw_ROOT}/opt/ruby/bin/rake" "$@"
+}
+
+setup
+main "$@"

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+setup() {
+    local a xdg_config
+    IFS=: read -a xdg_config <<< "${XDG_CONFIG_HOME:-$HOME/.config}:${XDG_CONFIG_DIRS:-/etc/xdg}"
+    for a in "${xdg_config[@]}"; do
+        if [ -e "${a}"/clusterware/config.rc ]; then
+            source "${a}"/clusterware/config.rc
+            break
+        fi
+    done
+    if [ -z "${cw_ROOT}" ]; then
+        echo "$0: unable to locate clusterware configuration"
+        exit 1
+    fi
+    kernel_load
+}
+
+main() {
+    # Adapted from Gridware installation process in
+    # $clusterware-services/gridware/metadata.yml
+    yum install -y gcc-c++ gmp-devel sqlite-devel
+    PATH="${cw_ROOT}/opt/git/bin:${cw_ROOT}/opt/ruby/bin:$PATH"
+    bundle install --local --path=vendor
+}
+
+setup
+main

--- a/lib/alces/packager/depot.rb
+++ b/lib/alces/packager/depot.rb
@@ -89,6 +89,13 @@ module Alces
       def disable
         if !enabled?
           say("#{"WARNING!".color(:yellow)} Depot already disabled: #{name}")
+        elsif loaded_modules?
+          say "\n#{"ERROR".color(:red).underline}: The following modules have been loaded from this depot and must be unloaded to continue:\n\n"
+          loaded_modules.each do |mod|
+            say " - #{mod}"
+          end
+          say "\nThis can be done using `alces module purge` or `alces module unload $module`\n\n"
+          return false
         else
           title "Disabling depot: #{name}"
           doing 'Disable'
@@ -259,6 +266,10 @@ EOF
         end
       end
 
+      def path
+        depot_path(name)
+      end
+
       def depot_path(name)
         File.join(Config.depotroot,name)
       end
@@ -269,6 +280,22 @@ EOF
 
       def depot_install_path(identifier)
         File.join(depot_root,identifier.to_s)
+      end
+
+      def provides_module(module_path)
+        module_path =~ /^#{path}/
+      end
+
+      def loaded_modules?
+        !loaded_modules.empty?
+      end
+
+      def loaded_modules
+        all_loaded_modules.select {|module_path| provides_module(module_path)}
+      end
+
+      def all_loaded_modules
+        (ENV['_LMFILES_'] || '').split(':')
       end
     end
   end

--- a/lib/alces/packager/tests/test_handler.rb
+++ b/lib/alces/packager/tests/test_handler.rb
@@ -83,7 +83,7 @@ class TestHandlerProxy < MiniTest::Test
     end
 
     def actions_requiring_update
-      Alces::Packager::HandlerProxy::ACTIONS_REQUIRING_UPDATE
+      Alces::Packager::HandlerProxy::ACTIONS_REQUIRING_PACKAGE_REPO_UPDATE
     end
 
     def actions_not_requiring_update


### PR DESCRIPTION
This PR resolves #5; this is done more simply than is suggested in the original issue due to the discussion starting at https://alces.slack.com/archives/gridware/p1480509831000216. This is based on https://github.com/alces-software/gridware/pull/11.