### PR TITLE
Userspace Gridware

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,6 @@ GEM
       mime-types (~> 1.15)
       posix-spawn (~> 0.3.6)
     highline (1.7.3)
-    hpricot (0.8.6)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     json (1.8.3)
@@ -56,18 +55,12 @@ GEM
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.11.2)
-    mustache (1.0.2)
     netrc (0.10.3)
     posix-spawn (0.3.11)
-    rdiscount (2.1.8)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    ronn (0.7.3)
-      hpricot (>= 0.8.2)
-      mustache (>= 0.7.0)
-      rdiscount (>= 1.5.8)
     rubytree (0.9.6)
       json (~> 1.8)
       structured_warnings (~> 0.2)
@@ -92,9 +85,8 @@ DEPENDENCIES
   memoist
   minitest
   mocha
-  ronn
   rubytree
   terminal-table
 
 BUNDLED WITH
-   1.10.6
+   1.13.7

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 
-#Gridware
+# Gridware
 
 This is the repository for the Alces Gridware tool for installing and managing
 HPC software. Alces Gridware is intended to be used in an [Alces
 Clusterware](https://github.com/alces-software/clusterware) environment, such
 as [Alces Flight Compute](http://alces-flight.com/).
 
-##Development
+## Development
 
 Gridware can be developed within an existing Clusterware environment. For
 example, to use a local version of the Gridware source inside an Alces
@@ -17,7 +17,7 @@ Clusterware development Vagrant VM you can do the following:
    `vagrant up`:
 
    ```ruby
-  config.vm.synced_folder "path/to/gridware", "/opt/clusterware/opt/gridware"
+      config.vm.synced_folder "path/to/gridware", "/opt/clusterware/opt/gridware"
    ```
 
 2. Install the mounted version of Gridware within the VM by running

--- a/lib/alces/packager/actions.rb
+++ b/lib/alces/packager/actions.rb
@@ -704,9 +704,8 @@ EOF
 
       private
       def correct_permissions
-        FileUtils.chown_R(nil, 'gridware', dest_dir)
         FileUtils.chmod_R("ug+w,a+r", dest_dir, force: true)
-        FileUtils.chmod("g+xs,a+x", directories_within(dest_dir))
+        FileUtils.chmod("u+xs,a+x", directories_within(dest_dir))
       end
 
       def directories_within(base)

--- a/lib/alces/packager/actions.rb
+++ b/lib/alces/packager/actions.rb
@@ -670,7 +670,8 @@ EOF
       def dependency_script(phase)
         if package.metadata[:dependencies]
           %(#=Alces-Gridware-Dependencies:2
-sudo -E #{ENV['cw_ROOT']}/bin/alces gridware distro_deps #{package.path} --phase #{phase} --log-root #{Config.log_root})
+cw_GRIDWARE_userspace=#{ENV['cw_GRIDWARE_userspace']}
+sudo -E #{ENV['cw_ROOT']}/bin/alces gridware distro_deps #{package.path} --phase #{phase})
         end
       end
 

--- a/lib/alces/packager/actions.rb
+++ b/lib/alces/packager/actions.rb
@@ -669,7 +669,8 @@ EOF
 
       def dependency_script(phase)
         if package.metadata[:dependencies]
-          "sudo -E #{ENV['cw_ROOT']}/bin/alces gridware distro_deps #{package.path} --phase #{phase} --log-root #{Config.log_root}"
+          %(#=Alces-Gridware-Dependencies:2
+sudo -E #{ENV['cw_ROOT']}/bin/alces gridware distro_deps #{package.path} --phase #{phase} --log-root #{Config.log_root})
         end
       end
 

--- a/lib/alces/packager/actions.rb
+++ b/lib/alces/packager/actions.rb
@@ -28,6 +28,7 @@ require 'alces/packager/module_tree'
 require 'alces/packager/package'
 require 'alces/packager/errors'
 require 'alces/packager/config'
+require 'alces/packager/dependency_utils'
 require 'memoist'
 require 'find'
 
@@ -669,9 +670,7 @@ EOF
 
       def dependency_script(phase)
         if package.metadata[:dependencies]
-          %(#=Alces-Gridware-Dependencies:2
-cw_GRIDWARE_userspace=#{ENV['cw_GRIDWARE_userspace']}
-sudo -E #{ENV['cw_ROOT']}/bin/alces gridware distro_deps #{package.path} --phase #{phase})
+          DependencyUtils.generate_dependency_script(package.path, phase)
         end
       end
 

--- a/lib/alces/packager/archive_importer.rb
+++ b/lib/alces/packager/archive_importer.rb
@@ -132,6 +132,7 @@ module Alces
       private
 
       def handle_failure!(res)
+        msg = 'Installing dependencies failed.'
         err_lines = res.stderr.split("\n")
         max_lines = err_lines.length > 10 ? 10 : err_lines.length
         msg << "\n\n   Extract of script error output:\n   > " << err_lines[-max_lines..-1].reject{|x| !options.verbose && x[0] == '+'}.map(&:strip).join("\n   > ")

--- a/lib/alces/packager/archive_importer.rb
+++ b/lib/alces/packager/archive_importer.rb
@@ -234,11 +234,6 @@ module Alces
             tgt_depends_file = File.join(dest_depends_dir, "#{[type, name, version, tagging[:tag]].join('-')}.sh")
             tgt_pkg_dir = File.join(dest_pkg_dir, tagging[:tag])
 
-            FileUtils.chown(nil, 'gridware', tgt_depends_file) if File.exists?(tgt_depends_file)
-            FileUtils.chown(nil, 'gridware', tgt_module_file)
-            FileUtils.chown_R(nil, 'gridware', tgt_pkg_dir)
-            FileUtils.chmod_R("g+w", tgt_pkg_dir, force: true)
-            FileUtils.chmod("g+xs", directories_within(tgt_pkg_dir))
           end
           say 'OK'.color(:green)
         end
@@ -315,13 +310,6 @@ module Alces
           tgt_lib_module_file = File.join(dest_lib_module_dir, version)
           tgt_depends_file = File.join(dest_depends_dir, "#{['compilers', name, version].join('-')}.sh")
           tgt_pkg_dir = File.join(dest_pkg_dir, version)
-
-          FileUtils.chown(nil, 'gridware', tgt_depends_file) if File.exists?(tgt_depends_file)
-          FileUtils.chown(nil, 'gridware', tgt_compiler_module_file)
-          FileUtils.chown(nil, 'gridware', tgt_lib_module_file)
-          FileUtils.chown_R(nil, 'gridware', tgt_pkg_dir)
-          FileUtils.chmod_R("g+w", tgt_pkg_dir, force: true)
-          FileUtils.chmod("g+xs", directories_within(tgt_pkg_dir))
         end
         say 'OK'.color(:green)
       end

--- a/lib/alces/packager/archive_importer.rb
+++ b/lib/alces/packager/archive_importer.rb
@@ -223,19 +223,6 @@ module Alces
           else
             say 'OK'.color(:green)
           end
-
-          doing 'Permissions'
-          with_spinner do
-            # fix permissions on:
-            #   - modulefile
-            #   - depends file
-            #   - package tree
-            tgt_module_file = File.join(dest_module_dir, tagging[:tag])
-            tgt_depends_file = File.join(dest_depends_dir, "#{[type, name, version, tagging[:tag]].join('-')}.sh")
-            tgt_pkg_dir = File.join(dest_pkg_dir, tagging[:tag])
-
-          end
-          say 'OK'.color(:green)
         end
       end
 
@@ -299,19 +286,6 @@ module Alces
         else
           say 'OK'.color(:green)
         end
-
-        doing 'Permissions'
-        with_spinner do
-          # fix permissions on:
-          #   - modulefiles
-          #   - depends file
-          #   - package tree
-          tgt_compiler_module_file = File.join(dest_compiler_module_dir, version)
-          tgt_lib_module_file = File.join(dest_lib_module_dir, version)
-          tgt_depends_file = File.join(dest_depends_dir, "#{['compilers', name, version].join('-')}.sh")
-          tgt_pkg_dir = File.join(dest_pkg_dir, version)
-        end
-        say 'OK'.color(:green)
       end
 
       def load_metadata(dir)

--- a/lib/alces/packager/cli.rb
+++ b/lib/alces/packager/cli.rb
@@ -265,6 +265,7 @@ Perform a depot operation. Supported operations:
         c.syntax = 'alces gridware distro_deps <distro_pkg> [<distro_pkg> [...]]'
         c.description = 'Install dependencies from the distribution\'s package manager'
         c.action HandlerProxy, :distro_deps
+        c.option '-p', '--phase STRING', String, 'Phase to install dependencies for (e.g. build, runtime)'
       end
     end
   end

--- a/lib/alces/packager/cli.rb
+++ b/lib/alces/packager/cli.rb
@@ -274,11 +274,10 @@ Perform a depot operation. Supported operations:
         c.description = <<-EOF
 Perform operations on distribution package installation requests. Supported operations:
 
-  list             List all pending installation requests
-  install [--all]  Install requested packages
+  list     List all pending installation requests
+  install  Install requested packages
         EOF
         c.action HandlerProxy, :package_requests
-        c.option '-a', '--all', 'Install all requested packages without confirmation'
       end
     end
   end

--- a/lib/alces/packager/cli.rb
+++ b/lib/alces/packager/cli.rb
@@ -274,9 +274,11 @@ Perform a depot operation. Supported operations:
         c.description = <<-EOF
 Perform operations on distribution package installation requests. Supported operations:
 
-  (none - coming soon™)
+  list             List all pending installation requests
+  install [--all]  Install requested packages
         EOF
         c.action HandlerProxy, :package_requests
+        c.option '-a', '--all', 'Install all requested packages without confirmation'
       end
     end
   end

--- a/lib/alces/packager/cli.rb
+++ b/lib/alces/packager/cli.rb
@@ -266,6 +266,7 @@ Perform a depot operation. Supported operations:
         c.description = 'Install dependencies from the distribution\'s package manager'
         c.action HandlerProxy, :distro_deps
         c.option '-p', '--phase STRING', String, 'Phase to install dependencies for (e.g. build, runtime)'
+        c.option '-l', '--log-root STRING', String, 'Path to log root directory'
       end
     end
   end

--- a/lib/alces/packager/cli.rb
+++ b/lib/alces/packager/cli.rb
@@ -266,7 +266,6 @@ Perform a depot operation. Supported operations:
         c.description = 'Install dependencies from the distribution\'s package manager'
         c.action HandlerProxy, :distro_deps
         c.option '-p', '--phase STRING', String, 'Phase to install dependencies for (e.g. build, runtime)'
-        c.option '-l', '--log-root STRING', String, 'Path to log root directory'
       end
     end
   end

--- a/lib/alces/packager/cli.rb
+++ b/lib/alces/packager/cli.rb
@@ -267,6 +267,17 @@ Perform a depot operation. Supported operations:
         c.action HandlerProxy, :distro_deps
         c.option '-p', '--phase STRING', String, 'Phase to install dependencies for (e.g. build, runtime)'
       end
+
+      command :package_requests do |c|
+        c.syntax = 'alces gridware package_requests <operation>'
+        c.summary = 'Perform operations on distribution package installation requests'
+        c.description = <<-EOF
+Perform operations on distribution package installation requests. Supported operations:
+
+  (none - coming soon™)
+        EOF
+        c.action HandlerProxy, :package_requests
+      end
     end
   end
 end

--- a/lib/alces/packager/cli.rb
+++ b/lib/alces/packager/cli.rb
@@ -240,7 +240,7 @@ Perform a depot operation. Supported operations:
         c.option '--tree', 'Display dependency tree for package'
         c.option '--ignore-satisfied', 'Only display unsatisfied dependencies'
       end
-      set_aliases(:requires, extra: :reqs)
+      set_aliases(:requires, extra: :reqs, min: 4)
 
       command :export do |c|
         c.syntax = 'alces gridware export <package path>'
@@ -261,15 +261,16 @@ Perform a depot operation. Supported operations:
       end
       set_aliases(:import, min: 2)
 
-      command :distro_deps do |c|
-        c.syntax = 'alces gridware distro_deps <distro_pkg> [<distro_pkg> [...]]'
+      command :dependencies do |c|
+        c.syntax = 'alces gridware dependencies <distro_pkg> [<distro_pkg> [...]]'
         c.description = 'Install dependencies from the distribution\'s package manager'
         c.action HandlerProxy, :distro_deps
         c.option '-p', '--phase STRING', String, 'Phase to install dependencies for (e.g. build, runtime)'
       end
+      set_aliases(:dependencies, min: 4, extra: :deps)
 
-      command :package_requests do |c|
-        c.syntax = 'alces gridware package_requests <operation>'
+      command :requests do |c|
+        c.syntax = 'alces gridware requests <operation>'
         c.summary = 'Perform operations on distribution package installation requests'
         c.description = <<-EOF
 Perform operations on distribution package installation requests. Supported operations:
@@ -279,6 +280,7 @@ Perform operations on distribution package installation requests. Supported oper
         EOF
         c.action HandlerProxy, :package_requests
       end
+      set_aliases(:requests, min: 4, extra: :rq)
     end
   end
 end

--- a/lib/alces/packager/cli.rb
+++ b/lib/alces/packager/cli.rb
@@ -260,6 +260,12 @@ Perform a depot operation. Supported operations:
         c.action HandlerProxy, :import
       end
       set_aliases(:import, min: 2)
+
+      command :distro_deps do |c|
+        c.syntax = 'alces gridware distro_deps <distro_pkg> [<distro_pkg> [...]]'
+        c.description = 'Install dependencies from the distribution\'s package manager'
+        c.action HandlerProxy, :distro_deps
+      end
     end
   end
 end

--- a/lib/alces/packager/config.rb
+++ b/lib/alces/packager/config.rb
@@ -45,11 +45,15 @@ module Alces
             cfgfile = Alces::Tools::Config.find("gridware", false)
             h.merge!(YAML.load_file(cfgfile)) unless cfgfile.nil?
 
-            if ENV['cw_GRIDWARE_userspace'] == 'true'
+            if userspace?
               h.merge!(USERSPACE_CONFIG)
             end
 
           end
+        end
+
+        def userspace?
+          ENV['cw_GRIDWARE_userspace'] == 'true'
         end
 
         def packages_dir(depot)

--- a/lib/alces/packager/config.rb
+++ b/lib/alces/packager/config.rb
@@ -32,10 +32,10 @@ module Alces
       }
 
       USERSPACE_CONFIG = {
-          log_root: File.expand_path('~/.cache/gridware/log'),
-          archives_dir: File.expand_path('~/.cache/gridware/cache/archives'),
-          buildroot: File.expand_path('~/.cache/gridware/cache/src'),
-          depotroot: File.expand_path('~/gridware'),
+          log_root: File.expand_path("~#{ENV['cw_GRIDWARE_userspace']}/.cache/gridware/log"),
+          archives_dir: File.expand_path("~#{ENV['cw_GRIDWARE_userspace']}/.cache/gridware/cache/archives"),
+          buildroot: File.expand_path("~#{ENV['cw_GRIDWARE_userspace']}/.cache/gridware/cache/src"),
+          depotroot: File.expand_path("~#{ENV['cw_GRIDWARE_userspace']}/gridware"),
           default_depot: 'personal'
       }
 
@@ -53,7 +53,7 @@ module Alces
         end
 
         def userspace?
-          ENV['cw_GRIDWARE_userspace'] == 'true'
+          ENV.has_key?('cw_GRIDWARE_userspace')
         end
 
         def packages_dir(depot)

--- a/lib/alces/packager/config.rb
+++ b/lib/alces/packager/config.rb
@@ -55,6 +55,14 @@ module Alces
           File.expand_path(File.join(depot_path(depot),'etc'))
         end
 
+        def log_root
+          if ENV['cw_GRIDWARE_userspace'] == 'true'
+            File.expand_path('~/.cache/gridware/log')
+          else
+            method_missing(:log_root)
+          end
+        end
+
         def method_missing(s,*a,&b)
           if config.has_key?(s)
             config[s]

--- a/lib/alces/packager/config.rb
+++ b/lib/alces/packager/config.rb
@@ -31,11 +31,24 @@ module Alces
         use_default_params: false
       }
 
+      USERSPACE_CONFIG = {
+          log_root: File.expand_path('~/.cache/gridware/log'),
+          archives_dir: File.expand_path('~/.cache/gridware/cache/archives'),
+          buildroot: File.expand_path('~/.cache/gridware/cache/src'),
+          depotroot: File.expand_path('~/gridware'),
+          default_depot: 'personal'
+      }
+
       class << self
         def config
           @config ||= DEFAULT_CONFIG.dup.tap do |h|
             cfgfile = Alces::Tools::Config.find("gridware", false)
             h.merge!(YAML.load_file(cfgfile)) unless cfgfile.nil?
+
+            if ENV['cw_GRIDWARE_userspace'] == 'true'
+              h.merge!(USERSPACE_CONFIG)
+            end
+
           end
         end
 
@@ -55,43 +68,9 @@ module Alces
           File.expand_path(File.join(depot_path(depot),'etc'))
         end
 
-        def log_root
-          if ENV['cw_GRIDWARE_userspace'] == 'true'
-            File.expand_path('~/.cache/gridware/log')
-          else
-            method_missing(:log_root)
-          end
-        end
-
-        def archives_dir
-          if ENV['cw_GRIDWARE_userspace'] == 'true'
-            File.expand_path('~/.cache/gridware/cache/archives')
-          else
-            method_missing(:archives_dir)
-          end
-        end
-
-        def buildroot
-          if ENV['cw_GRIDWARE_userspace'] == 'true'
-            File.expand_path('~/.cache/gridware/cache/src')
-          else
-            method_missing(:build_root)
-          end
-        end
-
-        def depotroot
-          if ENV['cw_GRIDWARE_userspace'] == 'true'
-            File.expand_path('~/gridware')
-          else
-            method_missing(:build_root)
-          end
-        end
-
         def default_depot
-          if ENV['cw_GRIDWARE_userspace'] == 'true'
-            'personal'
-          elsif config.has_key?('default_depot')
-            config['default_depot']
+          if config.has_key?(:default_depot)
+            config[:default_depot]
           else
             'local'
           end

--- a/lib/alces/packager/config.rb
+++ b/lib/alces/packager/config.rb
@@ -63,6 +63,30 @@ module Alces
           end
         end
 
+        def archives_dir
+          if ENV['cw_GRIDWARE_userspace'] == 'true'
+            File.expand_path('~/.cache/gridware/cache/archives')
+          else
+            method_missing(:archives_dir)
+          end
+        end
+
+        def buildroot
+          if ENV['cw_GRIDWARE_userspace'] == 'true'
+            File.expand_path('~/.cache/gridware/cache/src')
+          else
+            method_missing(:build_root)
+          end
+        end
+
+        def depotroot
+          if ENV['cw_GRIDWARE_userspace'] == 'true'
+            File.expand_path('~/gridware')
+          else
+            method_missing(:build_root)
+          end
+        end
+
         def method_missing(s,*a,&b)
           if config.has_key?(s)
             config[s]

--- a/lib/alces/packager/config.rb
+++ b/lib/alces/packager/config.rb
@@ -87,6 +87,16 @@ module Alces
           end
         end
 
+        def default_depot
+          if config.has_key?('default_depot')
+            config['default_depot']
+          elsif ENV['cw_GRIDWARE_userspace'] == 'true'
+            'personal'
+          else
+            'local'
+          end
+        end
+
         def method_missing(s,*a,&b)
           if config.has_key?(s)
             config[s]

--- a/lib/alces/packager/config.rb
+++ b/lib/alces/packager/config.rb
@@ -88,10 +88,10 @@ module Alces
         end
 
         def default_depot
-          if config.has_key?('default_depot')
-            config['default_depot']
-          elsif ENV['cw_GRIDWARE_userspace'] == 'true'
+          if ENV['cw_GRIDWARE_userspace'] == 'true'
             'personal'
+          elsif config.has_key?('default_depot')
+            config['default_depot']
           else
             'local'
           end

--- a/lib/alces/packager/dependency_utils.rb
+++ b/lib/alces/packager/dependency_utils.rb
@@ -7,7 +7,7 @@ module Alces
 
         def generate_dependency_script(package_path, phase)
           %(#=Alces-Gridware-Dependencies:2
-sudo -E cw_GRIDWARE_userspace=#{ENV['cw_GRIDWARE_userspace']} #{ENV['cw_ROOT']}/bin/alces gridware distro_deps #{strip_variant(package_path)} --phase #{phase})
+sudo -E cw_GRIDWARE_userspace=#{ENV['cw_GRIDWARE_userspace']} #{ENV['cw_ROOT']}/bin/alces gridware dependencies #{strip_variant(package_path)} --phase #{phase})
         end
 
         def whitelist

--- a/lib/alces/packager/dependency_utils.rb
+++ b/lib/alces/packager/dependency_utils.rb
@@ -1,3 +1,5 @@
+require 'yaml'
+
 module Alces
   module Packager
     class DependencyUtils
@@ -8,6 +10,10 @@ module Alces
 sudo -E cw_GRIDWARE_userspace=#{ENV['cw_GRIDWARE_userspace']} #{ENV['cw_ROOT']}/bin/alces gridware distro_deps #{strip_variant(package_path)} --phase #{phase})
         end
 
+        def whitelist
+          @whitelist ||= empty_whitelist.merge(whitelist_from_file)
+        end
+
         private
 
         def strip_variant(package_path)
@@ -15,6 +21,18 @@ sudo -E cw_GRIDWARE_userspace=#{ENV['cw_GRIDWARE_userspace']} #{ENV['cw_ROOT']}/
           # remove _ and everything subsequent up until the next /
           # This assumes we always get a full package path including version...
           package_path.gsub(/_[^\/]+(\/[^\/]+)$/, '\1')
+        end
+
+        def whitelist_from_file
+          YAML.load_file(whitelist_file) rescue {}
+        end
+
+        def whitelist_file
+          File.join(Config.gridware, 'etc', 'whitelist.yml')
+        end
+
+        def empty_whitelist
+          { users: [], packages: [], repos: [] }
         end
 
       end

--- a/lib/alces/packager/dependency_utils.rb
+++ b/lib/alces/packager/dependency_utils.rb
@@ -6,7 +6,16 @@ module Alces
         def generate_dependency_script(package_path, phase)
           %(#=Alces-Gridware-Dependencies:2
 cw_GRIDWARE_userspace=#{ENV['cw_GRIDWARE_userspace']}
-sudo -E #{ENV['cw_ROOT']}/bin/alces gridware distro_deps #{package_path} --phase #{phase})
+sudo -E #{ENV['cw_ROOT']}/bin/alces gridware distro_deps #{strip_variant(package_path)} --phase #{phase})
+        end
+
+        private
+
+        def strip_variant(package_path)
+          # In the second-to-last component of the path (e.g. allow _ in version)
+          # remove _ and everything subsequent up until the next /
+          # This assumes we always get a full package path including version...
+          package_path.gsub(/_[^\/]+(\/[^\/]+)$/, '\1')
         end
 
       end

--- a/lib/alces/packager/dependency_utils.rb
+++ b/lib/alces/packager/dependency_utils.rb
@@ -14,6 +14,17 @@ sudo -E cw_GRIDWARE_userspace=#{ENV['cw_GRIDWARE_userspace']} #{ENV['cw_ROOT']}/
           @whitelist ||= empty_whitelist.merge(whitelist_from_file)
         end
 
+        def whitelist_package(pkg)
+          my_wl = whitelist
+
+          my_wl[:packages] << pkg
+          File.open(whitelist_file, 'w') do |wf|
+            wf.write(my_wl.to_yaml)
+          end
+
+          @whitelist = my_wl
+        end
+
         private
 
         def strip_variant(package_path)

--- a/lib/alces/packager/dependency_utils.rb
+++ b/lib/alces/packager/dependency_utils.rb
@@ -5,8 +5,7 @@ module Alces
 
         def generate_dependency_script(package_path, phase)
           %(#=Alces-Gridware-Dependencies:2
-cw_GRIDWARE_userspace=#{ENV['cw_GRIDWARE_userspace']}
-sudo -E #{ENV['cw_ROOT']}/bin/alces gridware distro_deps #{strip_variant(package_path)} --phase #{phase})
+sudo -E cw_GRIDWARE_userspace=#{ENV['cw_GRIDWARE_userspace']} #{ENV['cw_ROOT']}/bin/alces gridware distro_deps #{strip_variant(package_path)} --phase #{phase})
         end
 
         private

--- a/lib/alces/packager/dependency_utils.rb
+++ b/lib/alces/packager/dependency_utils.rb
@@ -1,0 +1,15 @@
+module Alces
+  module Packager
+    class DependencyUtils
+      class << self
+
+        def generate_dependency_script(package_path, phase)
+          %(#=Alces-Gridware-Dependencies:2
+cw_GRIDWARE_userspace=#{ENV['cw_GRIDWARE_userspace']}
+sudo -E #{ENV['cw_ROOT']}/bin/alces gridware distro_deps #{package_path} --phase #{phase})
+        end
+
+      end
+    end
+  end
+end

--- a/lib/alces/packager/depot.rb
+++ b/lib/alces/packager/depot.rb
@@ -252,6 +252,7 @@ EOF
 
       private
       def notify_depot(name, state)
+        return if Config.userspace?
         if ENV['cw_GRIDWARE_notify'] == 'true'
           id = File.basename(File.readlink(depot_path(name)))
           run(File.join(ENV['cw_ROOT'],'libexec','share','trigger-depot-event'),

--- a/lib/alces/packager/depot.rb
+++ b/lib/alces/packager/depot.rb
@@ -276,7 +276,7 @@ EOF
       end
 
       def user_modulespaths
-        f = File.expand_path('~/.modulespath')
+        f = File.expand_path("~#{ENV['cw_GRIDWARE_userspace']}/.modulespath")
         paths = File.exist?(f) ? File.read(f).split("\n") : []
       end
 

--- a/lib/alces/packager/depot.rb
+++ b/lib/alces/packager/depot.rb
@@ -107,7 +107,7 @@ module Alces
       end
 
       def enabled?
-        global_modulespaths.include?(target) || user_modulespaths.include?(target)
+        global_modulespaths.include?(target) || (Config.userspace? && user_modulespaths.include?(target))
       end
 
       def init(disabled = false)

--- a/lib/alces/packager/depot.rb
+++ b/lib/alces/packager/depot.rb
@@ -107,7 +107,7 @@ module Alces
       end
 
       def enabled?
-        global_modulespaths.include?(target)
+        global_modulespaths.include?(target) || user_modulespaths.include?(target)
       end
 
       def init(disabled = false)
@@ -260,8 +260,18 @@ EOF
         paths = File.exist?(f) ? File.read(f).split("\n") : []
       end
 
+      def user_modulespaths
+        f = File.expand_path('~/.modulespath')
+        paths = File.exist?(f) ? File.read(f).split("\n") : []
+      end
+
       def modulespaths(&block)
-        f = File.join(ENV['cw_ROOT'], 'etc', 'modulerc', 'modulespath')
+        if ENV['cw_GRIDWARE_notify'] == 'true'
+          f = File.expand_path('~/.modulespath')
+        else
+          f = File.join(ENV['cw_ROOT'], 'etc', 'modulerc', 'modulespath')
+        end
+
         paths = File.exist?(f) ? File.read(f).split("\n") : []
         if block.call(paths)
           File.write(f, paths.join("\n"))

--- a/lib/alces/packager/depot.rb
+++ b/lib/alces/packager/depot.rb
@@ -266,7 +266,7 @@ EOF
       end
 
       def modulespaths(&block)
-        if ENV['cw_GRIDWARE_notify'] == 'true'
+        if Config.userspace?
           f = File.expand_path('~/.modulespath')
         else
           f = File.join(ENV['cw_ROOT'], 'etc', 'modulerc', 'modulespath')

--- a/lib/alces/packager/depot.rb
+++ b/lib/alces/packager/depot.rb
@@ -132,7 +132,12 @@ module Alces
 
       def purge(non_interactive = false)
         say "Purging depot: #{name.color(:magenta).bold}"
-        files = [Depot.hash_path_for(name), depot_path(name)]
+        files = [
+            Depot.hash_path_for(name),
+            depot_path(name),
+            (File.readlink(File.join(depot_path(name), '.gridware-userspace')) rescue nil)
+        ].compact
+
         msg = <<EOF
 Purge operation will remove the following files/directories:
   #{files.join("\n  ")}

--- a/lib/alces/packager/depot_handler.rb
+++ b/lib/alces/packager/depot_handler.rb
@@ -127,6 +127,8 @@ module Alces
             say "#{'SKIP'.color(:yellow)} (Not updateable, no remote configured)"
           when :outofsync
             say "#{'SKIP'.color(:yellow)} (Out of sync: #{rev})"
+          when :nopermission
+            say "#{'SKIP'.color(:yellow)} (No permission)"
           end
         rescue
           say "#{'FAIL'.color(:red)} (#{$!.message})"

--- a/lib/alces/packager/depot_repo.rb
+++ b/lib/alces/packager/depot_repo.rb
@@ -83,6 +83,7 @@ module Alces
       end
 
       def update!
+        return [:nopermission, nil] unless File.stat(path).writable?
         if metadata.key?(:source)
           case r = Alces.git.sync(metadata_path, metadata[:source])
           when /^Branch master set up/

--- a/lib/alces/packager/distro_deps_handler.rb
+++ b/lib/alces/packager/distro_deps_handler.rb
@@ -127,9 +127,9 @@ module Alces
       def install_cmd
         case cw_dist
           when /^el/
-            "/usr/bin/yum install -y %s >>#{log_root}/dependso.log 2>&1"
+            "/usr/bin/yum install -y %s >>#{log_root}/depends.log 2>&1"
           when /^ubuntu/
-            "/usr/bin/apt-get install -y %s >>#{log_root}/dependso.log 2>&1"
+            "/usr/bin/apt-get install -y %s >>#{log_root}/depends.log 2>&1"
         end
       end
 

--- a/lib/alces/packager/distro_deps_handler.rb
+++ b/lib/alces/packager/distro_deps_handler.rb
@@ -42,7 +42,7 @@ module Alces
       end
 
       def install
-        if ENV['cw_GRIDWARE_userspace'] == 'true'
+        if Process.euid != 0
           warning 'This command must be executed with sudo.'
         else
           install_deps
@@ -117,7 +117,7 @@ module Alces
       end
 
       def user_whitelisted
-        whitelist[:users].include?(ENV['SUDO_USER'])
+        whitelist[:users].include?(ENV['cw_GRIDWARE_userspace'])
       end
 
       def package_whitelisted(pkg)

--- a/lib/alces/packager/distro_deps_handler.rb
+++ b/lib/alces/packager/distro_deps_handler.rb
@@ -127,9 +127,9 @@ module Alces
       def install_cmd
         case cw_dist
           when /^el/
-            "/usr/bin/yum install -y %s >>#{log_root}/depends.log 2>&1"
+            "/usr/bin/yum install -y %s >>#{Config.log_root}/depends.log 2>&1"
           when /^ubuntu/
-            "/usr/bin/apt-get install -y %s >>#{log_root}/depends.log 2>&1"
+            "/usr/bin/apt-get install -y %s >>#{Config.log_root}/depends.log 2>&1"
         end
       end
 
@@ -179,11 +179,6 @@ module Alces
 
       def empty_whitelist
         { users: [], packages: [], repos: [] }
-      end
-
-      def log_root
-        # This command is run as root but we may need to write to userspace log
-        options.log_root || Config.log_root
       end
 
     end

--- a/lib/alces/packager/distro_deps_handler.rb
+++ b/lib/alces/packager/distro_deps_handler.rb
@@ -1,0 +1,49 @@
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+require 'memoist'
+
+module Alces
+  module Packager
+    class DistroDepsHandler
+      extend Memoist
+      include Alces::Tools::Logging
+
+      class << self
+        def install(*a)
+          new(*a).install
+        end
+      end
+
+      delegate :say, :to => IoHandler
+
+      attr_accessor :options
+      def initialize(options)
+        self.options = options
+      end
+
+      def install()
+        say self.options.inspect
+      end
+    end
+  end
+end
+

--- a/lib/alces/packager/distro_deps_handler.rb
+++ b/lib/alces/packager/distro_deps_handler.rb
@@ -19,7 +19,7 @@
 # For more information on the Alces Clusterware, please visit:
 # https://github.com/alces-software/clusterware
 #==============================================================================
-require 'yaml'
+require 'alces/packager/dependency_utils'
 
 module Alces
   module Packager
@@ -196,15 +196,7 @@ module Alces
       end
 
       def whitelist
-        @whitelist ||= empty_whitelist.merge(whitelist_from_file)
-      end
-
-      def whitelist_from_file
-        YAML.load_file(File.join(Config.gridware, 'etc', 'whitelist.yml')) rescue {}
-      end
-
-      def empty_whitelist
-        { users: [], packages: [], repos: [] }
+        DependencyUtils.whitelist
       end
 
     end

--- a/lib/alces/packager/distro_deps_handler.rb
+++ b/lib/alces/packager/distro_deps_handler.rb
@@ -127,9 +127,9 @@ module Alces
       def install_cmd
         case cw_dist
           when /^el/
-            "/usr/bin/yum install -y %s >>#{Config.log_root}/depends.log 2>&1"
+            "/usr/bin/yum install -y %s >>#{log_root}/dependso.log 2>&1"
           when /^ubuntu/
-            "/usr/bin/apt-get install -y %s >>#{Config.log_root}/depends.log 2>&1"
+            "/usr/bin/apt-get install -y %s >>#{log_root}/dependso.log 2>&1"
         end
       end
 
@@ -179,6 +179,11 @@ module Alces
 
       def empty_whitelist
         { users: [], packages: [], repos: [] }
+      end
+
+      def log_root
+        # This command is run as root but we may need to write to userspace log
+        options.log_root || Config.log_root
       end
 
     end

--- a/lib/alces/packager/distro_deps_handler.rb
+++ b/lib/alces/packager/distro_deps_handler.rb
@@ -85,13 +85,15 @@ module Alces
 
       def required_distro_packages
         deps_hashes = [].tap do |a|
-          if defn.metadata[:dependencies][options.phase]
-            a << defn.metadata[:dependencies][options.phase]
-            if options.phase == :build && defn.metadata[:dependencies].key?(:runtime)
-              a << defn.metadata[:dependencies][:runtime]
+          if defn.metadata[:dependencies]
+            if defn.metadata[:dependencies][options.phase]
+              a << defn.metadata[:dependencies][options.phase]
+              if options.phase == :build && defn.metadata[:dependencies].key?(:runtime)
+                a << defn.metadata[:dependencies][:runtime]
+              end
+            else
+              a << defn.metadata[:dependencies]
             end
-          else
-            a << defn.metadata[:dependencies]
           end
         end
 

--- a/lib/alces/packager/distro_deps_handler.rb
+++ b/lib/alces/packager/distro_deps_handler.rb
@@ -119,7 +119,7 @@ module Alces
       end
 
       def user_whitelisted
-        Process.uid == 0 || whitelist[:users].include?(ENV['cw_GRIDWARE_userspace'])
+        (Process.uid == 0 && !ENV.has_key?('SUDO_USER')) || whitelist[:users].include?(ENV['cw_GRIDWARE_userspace'])
       end
 
       def package_whitelisted(pkg)

--- a/lib/alces/packager/distro_deps_handler.rb
+++ b/lib/alces/packager/distro_deps_handler.rb
@@ -71,12 +71,14 @@ module Alces
             else
               say 'PERMISSION DENIED'.color(:red)
               packages_without_permission << pkg
+              STDERR.puts "Permission denied when trying to install #{pkg}"
             end
           else
             raise NotFoundError, "Package #{pkg} is required but not available."
           end
         end
         if !packages_without_permission.empty?
+          STDERR.puts 'Some packages failed to install. Please contact your system administrator.'
           raise PermissionDeniedError, 'Some packages failed to install. Please contact your system administrator.'
         end
       end

--- a/lib/alces/packager/distro_deps_handler.rb
+++ b/lib/alces/packager/distro_deps_handler.rb
@@ -115,7 +115,7 @@ module Alces
       end
 
       def have_permission_to_install?(pkg)
-        user_whitelisted || package_whitelisted(pkg) || repo_whitelisted
+        allow_all || user_whitelisted || package_whitelisted(pkg) || repo_whitelisted
       end
 
       def user_whitelisted
@@ -128,6 +128,10 @@ module Alces
 
       def repo_whitelisted
         whitelist[:repos].include?(defn.repo.path)
+      end
+
+      def allow_all
+        whitelist[:allow_all] || false
       end
 
       def make_install_request(pkg)

--- a/lib/alces/packager/distro_deps_handler.rb
+++ b/lib/alces/packager/distro_deps_handler.rb
@@ -132,13 +132,13 @@ module Alces
 
       def make_install_request(pkg)
         system(
-            sprintf(
-                   install_request_command,
-                   ENV['cw_GRIDWARE_userspace'],
-                   defn,
-                   pkg,
-                   defn.repo.path
-            )
+          sprintf(
+            install_request_command,
+            ENV['cw_GRIDWARE_userspace'],
+            defn.name,
+            pkg,
+            defn.repo.path
+          )
         )
       end
 

--- a/lib/alces/packager/distro_deps_handler.rb
+++ b/lib/alces/packager/distro_deps_handler.rb
@@ -33,7 +33,7 @@ module Alces
         end
       end
 
-      delegate :doing, :say, :warning, :to => IoHandler
+      delegate :doing, :say, :warning, :with_spinner, :to => IoHandler
 
       attr_accessor :defn, :options
       def initialize(defn, options)
@@ -57,7 +57,10 @@ module Alces
           if installed?(pkg)
             say 'already installed'
           elsif available?(pkg)
-            # TODO check permissions and do installation
+            with_spinner do
+              # TODO check permissions and do installation
+            end
+            say 'TODO'.color(:yellow)
           else
             raise NotFoundError, "Package #{pkg} is required but not available."
           end

--- a/lib/alces/packager/distro_deps_handler.rb
+++ b/lib/alces/packager/distro_deps_handler.rb
@@ -174,7 +174,7 @@ module Alces
       end
 
       def install_request_command
-        "#{File.join(ENV['cw_ROOT'], 'libexec', 'share', 'distro-deps-notify')} %s %s %s %s"
+        "#{File.join(ENV['cw_ROOT'], 'libexec', 'share', 'distro-deps-notify')} \"%s\" \"%s\" \"%s\" \"%s\""
       end
 
       def stem

--- a/lib/alces/packager/distro_deps_handler.rb
+++ b/lib/alces/packager/distro_deps_handler.rb
@@ -33,15 +33,35 @@ module Alces
         end
       end
 
-      delegate :say, :to => IoHandler
+      delegate :say, :warning, :to => IoHandler
 
-      attr_accessor :options
-      def initialize(options)
+      attr_accessor :defn, :options
+      def initialize(defn, options)
+        self.defn = defn
         self.options = options
       end
 
-      def install()
-        say self.options.inspect
+      def install
+        if ENV['cw_GRIDWARE_userspace'] == 'true'
+          warning 'This command must be executed with sudo.'
+        else
+          install_deps
+        end
+      end
+
+      private
+
+      def install_deps
+        say 'Soon™'
+      end
+
+      def install_cmd
+        case ENV['cw_DIST']
+          when /^el/
+            "/usr/bin/yum install -y %s >>#{Config.log_root}/depends.log 2>&1"
+          when /^ubuntu/
+            "/usr/bin/apt-get install -y %s >>#{Config.log_root}/depends.log 2>&1"
+        end
       end
     end
   end

--- a/lib/alces/packager/distro_deps_handler.rb
+++ b/lib/alces/packager/distro_deps_handler.rb
@@ -119,7 +119,7 @@ module Alces
       end
 
       def user_whitelisted
-        whitelist[:users].include?(ENV['cw_GRIDWARE_userspace'])
+        Process.uid == 0 || whitelist[:users].include?(ENV['cw_GRIDWARE_userspace'])
       end
 
       def package_whitelisted(pkg)

--- a/lib/alces/packager/errors.rb
+++ b/lib/alces/packager/errors.rb
@@ -45,6 +45,8 @@ module Alces
     end
     class PermissionDeniedError < Alces::Tools::CLI::BadOutcome
     end
+    class ConfigurationError < Alces::Tools::CLI::BadOutcome
+    end
   end
 end
 

--- a/lib/alces/packager/errors.rb
+++ b/lib/alces/packager/errors.rb
@@ -43,6 +43,8 @@ module Alces
     end
     class ModulefileWarning < Alces::Tools::CLI::BadOutcome
     end
+    class PermissionDeniedError < Alces::Tools::CLI::BadOutcome
+    end
   end
 end
 

--- a/lib/alces/packager/handler.rb
+++ b/lib/alces/packager/handler.rb
@@ -240,7 +240,11 @@ module Alces
       end
 
       def distro_deps
-        DistroDepsHandler.install(options)
+        with_depot do
+          with_definition do |defn|
+            DistroDepsHandler.install(defn, options)
+          end
+        end
       end
 
       private

--- a/lib/alces/packager/handler.rb
+++ b/lib/alces/packager/handler.rb
@@ -203,6 +203,8 @@ module Alces
             say "#{'SKIP'.color(:yellow)} (Not updateable, no remote configured)"
           when :outofsync
             say "#{'SKIP'.color(:yellow)} (Out of sync: #{rev})"
+          when :nopermission
+            say "#{'SKIP'.color(:yellow)} (No permission)"
           end
         rescue
           say "#{'FAIL'.color(:red)} (#{$!.message})"

--- a/lib/alces/packager/handler.rb
+++ b/lib/alces/packager/handler.rb
@@ -34,6 +34,7 @@ require 'alces/packager/io_handler'
 require 'alces/packager/dependency_handler'
 require 'alces/packager/depot_handler'
 require 'alces/packager/distro_deps_handler'
+require 'alces/packager/package_requests_handler'
 require 'alces/packager/option_set'
 require 'terminal-table'
 require 'memoist'
@@ -245,6 +246,11 @@ module Alces
             DistroDepsHandler.install(defn, options)
           end
         end
+      end
+
+      def package_requests
+        raise MissingArgumentError, 'Please supply an operation' if options.args.empty?
+        PackageRequestsHandler.handle(options)
       end
 
       private

--- a/lib/alces/packager/handler.rb
+++ b/lib/alces/packager/handler.rb
@@ -33,6 +33,7 @@ require 'alces/packager/errors'
 require 'alces/packager/io_handler'
 require 'alces/packager/dependency_handler'
 require 'alces/packager/depot_handler'
+require 'alces/packager/distro_deps_handler'
 require 'alces/packager/option_set'
 require 'terminal-table'
 require 'memoist'
@@ -236,6 +237,10 @@ module Alces
             DefinitionHandler.requires(defn, options)
           end
         end
+      end
+
+      def distro_deps
+        DistroDepsHandler.install(options)
       end
 
       private

--- a/lib/alces/packager/import_export_utils.rb
+++ b/lib/alces/packager/import_export_utils.rb
@@ -66,7 +66,6 @@ module Alces
           output.close
           stat = File.stat(f)
           File.chmod(stat.mode, out_file)
-          File.chown(stat.uid, stat.gid, out_file)
           File.rename(out_file, f)
         end
       end

--- a/lib/alces/packager/module_tree.rb
+++ b/lib/alces/packager/module_tree.rb
@@ -43,7 +43,7 @@ module Alces
             raise ModulefileError, "Unable to gain module directory lock (stale lock at #{lock_dir}?)"
           end
           begin
-            FileUtils.mkdir(lock_dir)
+            FileUtils.mkdir_p(lock_dir)
             block.call
           ensure
             FileUtils.rmdir(lock_dir)

--- a/lib/alces/packager/option_set.rb
+++ b/lib/alces/packager/option_set.rb
@@ -28,6 +28,7 @@ module Alces
       attr_accessor :tree, :ignore_satisfied
       attr_accessor :full, :oneline, :groups, :descriptions, :names
       attr_accessor :disabled, :compile, :explicit_depot
+      attr_accessor :phase
 
       def initialize(options = nil)
         unless options.nil?
@@ -74,6 +75,8 @@ module Alces
               options.explicit_depot
             end
           self.compile = options.compile
+
+          self.phase = options.phase
         end
 
         self.compiler ||= :first

--- a/lib/alces/packager/option_set.rb
+++ b/lib/alces/packager/option_set.rb
@@ -28,7 +28,7 @@ module Alces
       attr_accessor :tree, :ignore_satisfied
       attr_accessor :full, :oneline, :groups, :descriptions, :names
       attr_accessor :disabled, :compile, :explicit_depot
-      attr_accessor :phase
+      attr_accessor :phase, :log_root
 
       def initialize(options = nil)
         unless options.nil?
@@ -77,6 +77,7 @@ module Alces
           self.compile = options.compile
 
           self.phase = options.phase
+          self.log_root = options.log_root
         end
 
         self.compiler ||= :first

--- a/lib/alces/packager/option_set.rb
+++ b/lib/alces/packager/option_set.rb
@@ -77,7 +77,7 @@ module Alces
         end
 
         self.compiler ||= :first
-        self.depot ||= (Config.default_depot rescue 'local')
+        self.depot ||= (Config.default_depot)
       end
 
       def search_args

--- a/lib/alces/packager/option_set.rb
+++ b/lib/alces/packager/option_set.rb
@@ -28,7 +28,7 @@ module Alces
       attr_accessor :tree, :ignore_satisfied
       attr_accessor :full, :oneline, :groups, :descriptions, :names
       attr_accessor :disabled, :compile, :explicit_depot
-      attr_accessor :phase, :all
+      attr_accessor :phase
 
       def initialize(options = nil)
         unless options.nil?
@@ -77,7 +77,6 @@ module Alces
           self.compile = options.compile
 
           self.phase = options.phase
-          self.all = options.all
         end
 
         self.compiler ||= :first

--- a/lib/alces/packager/option_set.rb
+++ b/lib/alces/packager/option_set.rb
@@ -28,7 +28,7 @@ module Alces
       attr_accessor :tree, :ignore_satisfied
       attr_accessor :full, :oneline, :groups, :descriptions, :names
       attr_accessor :disabled, :compile, :explicit_depot
-      attr_accessor :phase, :log_root
+      attr_accessor :phase
 
       def initialize(options = nil)
         unless options.nil?
@@ -77,7 +77,6 @@ module Alces
           self.compile = options.compile
 
           self.phase = options.phase
-          self.log_root = options.log_root
         end
 
         self.compiler ||= :first

--- a/lib/alces/packager/option_set.rb
+++ b/lib/alces/packager/option_set.rb
@@ -28,7 +28,7 @@ module Alces
       attr_accessor :tree, :ignore_satisfied
       attr_accessor :full, :oneline, :groups, :descriptions, :names
       attr_accessor :disabled, :compile, :explicit_depot
-      attr_accessor :phase
+      attr_accessor :phase, :all
 
       def initialize(options = nil)
         unless options.nil?
@@ -77,6 +77,7 @@ module Alces
           self.compile = options.compile
 
           self.phase = options.phase
+          self.all = options.all
         end
 
         self.compiler ||= :first

--- a/lib/alces/packager/package_requests_handler.rb
+++ b/lib/alces/packager/package_requests_handler.rb
@@ -1,0 +1,56 @@
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+module Alces
+  module Packager
+    class PackageRequestsHandler
+
+      class << self
+        def handle(options)
+          ENV['cw_GRIDWARE_notify'] = 'false' unless options.notify
+          handler_opts = OptionSet.new(options)
+          op = options.args.first
+          handler_opts.args = options.args[1..-1]
+          @handler = new(handler_opts)
+          instance_methods(false).each do |m|
+            if is_method_shortcut(op, m)
+              @handler.send(m)
+              return
+            end
+          end
+          raise InvalidParameterError, "Unrecognised installation request operation: #{op}"
+        end
+
+        def is_method_shortcut(operation, method_identifier)
+          is_prefix = method_identifier =~ /^#{Regexp.escape(operation)}/
+          is_list_shortcut = method_identifier == :list && operation == 'ls'
+          is_prefix || is_list_shortcut
+        end
+      end
+
+      attr_accessor :options
+      def initialize(options)
+        self.options = options
+      end
+
+    end
+  end
+end

--- a/lib/alces/packager/package_requests_handler.rb
+++ b/lib/alces/packager/package_requests_handler.rb
@@ -20,6 +20,7 @@
 # https://github.com/alces-software/clusterware
 #==============================================================================
 
+require 'alces/packager/dependency_utils'
 require 'csv'
 require 'yaml'
 
@@ -82,6 +83,7 @@ module Alces
             if actually_install(md[2])
               File.unlink(request_file(rq))
               notify_user(md)
+              DependencyUtils.whitelist_package(md[2])
               say 'Done'.color(:green)
             else
               say 'INSTALL FAILED'.color(:red)

--- a/lib/alces/packager/package_requests_handler.rb
+++ b/lib/alces/packager/package_requests_handler.rb
@@ -59,7 +59,7 @@ module Alces
         self.options = options
       end
 
-      def list()
+      def list
         Alces::Packager::CLI.send(:enable_paging)
         say Terminal::Table.new(title: 'Pending installation requests',
                                 headings: ['User', 'Gridware package', 'Distro package', 'Repo path', 'Date'],

--- a/lib/alces/packager/package_requests_handler.rb
+++ b/lib/alces/packager/package_requests_handler.rb
@@ -150,7 +150,7 @@ module Alces
         system(
             sprintf(
                 user_notify_command,
-                *metadata,
+                *metadata[0..-2],
                 user_email(metadata[0])
             )
         )
@@ -161,7 +161,7 @@ module Alces
         if File.exists?(fp)
           user_conf = YAML.load_file(fp)
           if user_conf.has_key?(:user_email)
-            user_conf[:user_email]
+            return user_conf[:user_email]
           end
         end
 
@@ -169,7 +169,7 @@ module Alces
       end
 
       def user_notify_command
-        "#{File.join(ENV['cw_ROOT'], 'libexec', 'share', 'package-install-notify')} %s %s %s %s %s"
+        "#{File.join(ENV['cw_ROOT'], 'libexec', 'share', 'package-install-notify')} \"%s\" \"%s\" \"%s\" \"%s\" \"%s\""
       end
 
       def cw_dist

--- a/lib/alces/packager/package_requests_handler.rb
+++ b/lib/alces/packager/package_requests_handler.rb
@@ -93,6 +93,7 @@ module Alces
       private
 
       def request_files
+        return [] unless Dir.exists?(requests_dir)
         Dir.entries(requests_dir).reject do |f|
           f[0] == '.'
         end

--- a/lib/alces/packager/package_requests_handler.rb
+++ b/lib/alces/packager/package_requests_handler.rb
@@ -24,8 +24,13 @@ module Alces
     class PackageRequestsHandler
 
       class << self
+
         def handle(options)
-          ENV['cw_GRIDWARE_notify'] = 'false' unless options.notify
+
+          if Process.euid != 0
+            raise PermissionDeniedError, 'This command must be executed as root.'
+          end
+
           handler_opts = OptionSet.new(options)
           op = options.args.first
           handler_opts.args = options.args[1..-1]

--- a/lib/alces/packager/package_requests_handler.rb
+++ b/lib/alces/packager/package_requests_handler.rb
@@ -66,6 +66,14 @@ module Alces
                                 rows: request_files.map { |rid| metadata(rid) })
       end
 
+      def install
+        if options.all
+          say 'TODO Install all'
+        else
+          say 'TODO Install individual'
+        end
+      end
+
       private
 
       def request_files

--- a/lib/alces/packager/package_requests_handler.rb
+++ b/lib/alces/packager/package_requests_handler.rb
@@ -19,6 +19,9 @@
 # For more information on the Alces Clusterware, please visit:
 # https://github.com/alces-software/clusterware
 #==============================================================================
+
+require 'csv'
+
 module Alces
   module Packager
     class PackageRequestsHandler
@@ -54,6 +57,29 @@ module Alces
       attr_accessor :options
       def initialize(options)
         self.options = options
+      end
+
+      def list()
+        Alces::Packager::CLI.send(:enable_paging)
+        say <<-ERB.chomp
+<%= list(#{request_files.map { |rid| printable_request(rid) }.inspect}, :rows) %>
+        ERB
+      end
+
+      private
+
+      def request_files
+        Dir.entries(requests_dir).reject do |f|
+          f[0] == '.'
+        end
+      end
+
+      def requests_dir
+        File.join(Config.gridware, 'etc', 'package-requests')
+      end
+
+      def printable_request(request_id)
+        CSV.read(File.join(requests_dir, request_id),{col_sep: ' ', encoding: 'UTF-8'}).first.join("\t")
       end
 
     end

--- a/lib/alces/packager/package_requests_handler.rb
+++ b/lib/alces/packager/package_requests_handler.rb
@@ -61,9 +61,9 @@ module Alces
 
       def list()
         Alces::Packager::CLI.send(:enable_paging)
-        say <<-ERB.chomp
-<%= list(#{request_files.map { |rid| printable_request(rid) }.inspect}, :rows) %>
-        ERB
+        say Terminal::Table.new(title: 'Pending installation requests',
+                                headings: ['User', 'Gridware package', 'Distro package', 'Repo path', 'Date'],
+                                rows: request_files.map { |rid| metadata(rid) })
       end
 
       private
@@ -78,8 +78,9 @@ module Alces
         File.join(Config.gridware, 'etc', 'package-requests')
       end
 
-      def printable_request(request_id)
-        CSV.read(File.join(requests_dir, request_id),{col_sep: ' ', encoding: 'UTF-8'}).first.join("\t")
+      def metadata(request_id)
+        rq_file = File.join(requests_dir, request_id)
+        CSV.read(rq_file,{col_sep: ' ', encoding: 'UTF-8'}).first.tap { |m| m << File.mtime(rq_file)}
       end
 
     end

--- a/lib/alces/packager/package_requests_handler.rb
+++ b/lib/alces/packager/package_requests_handler.rb
@@ -112,7 +112,7 @@ module Alces
       end
 
       def confirm_install(rqid, metadata)
-        return true if options.all
+        return true if options.yes
 
         action = $terminal.ask("\nUser #{metadata[0]} wants to install package #{metadata[2].bold}. (I)nstall, (S)kip, (D)elete?") { |q| q.validate = /[IiDdSs]/ }
 

--- a/lib/alces/packager/repository.rb
+++ b/lib/alces/packager/repository.rb
@@ -143,6 +143,7 @@ module Alces
       end
 
       def update!
+        return [:nopermission, nil] unless File.stat(path).writable?
         if metadata.key?(:source)
           case r = Alces.git.sync(repo_path, metadata[:source])
           when /^Branch master set up/

--- a/lib/alces/packager/repository.rb
+++ b/lib/alces/packager/repository.rb
@@ -53,7 +53,20 @@ module Alces
             if Config.userspace?
               user_cfgfile = File.expand_path("~#{ENV['cw_GRIDWARE_userspace']}/.config/gridware/gridware.yml")
               user = YAML.load_file(user_cfgfile)
+              check_user_config(h, user)
               h.deep_merge!(user) if File.exists?(user_cfgfile)
+            end
+          end
+        end
+
+        def check_user_config(global, user)
+          global_repos = global[:repo_paths].map { |rp| File.basename(rp) }
+          if user[:repo_paths]
+            user[:repo_paths].each do |urp|
+              urn = File.basename(urp)
+              if global_repos.include?(urn)
+                raise ConfigurationError, "User repo #{urp} conflicts with system-wide repo with the same name (#{urn}). Please correct your configuration in ~/.config/gridware/gridware.yml."
+              end
             end
           end
         end

--- a/lib/alces/packager/repository.rb
+++ b/lib/alces/packager/repository.rb
@@ -52,7 +52,7 @@ module Alces
 
             if Config.userspace?
               user_cfgfile = File.expand_path("~#{ENV['cw_GRIDWARE_userspace']}/.config/gridware/gridware.yml")
-              user = YAML.load_file(user_cfgfile)
+              user = YAML.load_file(user_cfgfile) rescue {}
               check_user_config(h, user)
               h.deep_merge!(user) if File.exists?(user_cfgfile)
             end


### PR DESCRIPTION
This PR adds support for userspace operations to Gridware - that is, using Gridware as a non-root user.

All Gridware operations are supported:
 - Installing Gridware packages from binary or source
 - Exporting depots to a directory
 - Installing depots
 - Creating and purging user depots
 - Installing Gridware packages from user repos (including user clones of the `volatile` repo)

On login, configuration files and a user depot are created under `~/gridware`. By default, packages installed to user depots take priority over system depots. This can be managed via `$MODULEPATH` / `module use` / `module unuse` to reorder the depots' modules directories.

Additional packages from Perl CPAN, Python PyPI etc are installed to a user's home directory, allowing cluster-wide use.

In order to deal with installation of distro package dependencies for non-root users, a new whitelisting system has been created. Administrators can edit `/opt/gridware/etc/whitelist.yml`, containing the following three lists:
 - `:users`: users listed here are allowed to install any distro package.
 - `:packages`: the distro packages listed here may be installed by any user.
 - `:repos`: distro packages that are dependencies of packages in Gridware repos at the filesystem paths listed here may be installed by any user.

If a user tries to install a Gridware package that has distro dependencies not meeting these criteria, then a request is created to the system administrator(s). These can be viewed with the new `alces gridware requests list` command, and approved or rejected with `alces gridware requests install`. The latter supports the `--yes` option to automatically approve all pending requests; otherwise the admin is prompted for each request. Approved packages are added to the whitelist so that they can be automatically installed on compute nodes when required.

If an admin has configured an email address `$cw_GRIDWARE_admin_email` in `$cw_ROOT/etc/gridware.rc`, then they receive an email notification when a new request is generated.

If a user has configured an email address `:user_email` in `~/gridware/etc/gridware.yml`, then they receive an email notification when a request is approved.

Both of these actions can be customised by editing the `distro-deps-notify` and the `package-install-notify` scripts installed to `/opt/clusterware/libexec/share`. (See `clusterware-services` PR.)

In order to ensure that existing Gridware binary packages use the new distro dependency management system, we detect old-style dependency scripts within the packages and automatically replace them with newly-generated ones that defer to `alces gridware dependencies`.

Related PRs:

 - `clusterware-services`: https://github.com/alces-software/clusterware-services/pull/52
 - `clusterware-handlers`: https://github.com/alces-software/clusterware-handlers/pull/79